### PR TITLE
nix: overlay: improve `num` install overlay

### DIFF
--- a/nix/overlay/default.nix
+++ b/nix/overlay/default.nix
@@ -97,14 +97,10 @@ let
     # });
 
     num = super.num.overrideAttrs (selfAttrs: superAttrs: {
-      postInstall = ''
-        mkdir -p "$out/lib/ocaml/4.14.0/site-lib/stublibs"
-        mv $out/lib/ocaml/4.14.0/site-lib/num/*.so "$out/lib/ocaml/4.14.0/site-lib/stublibs"
-      '';
       installPhase = ''
-          # Not sure if this is entirely correct, but opaline doesn't like `lib_root`
+          # opaline does not support lib_root
           substituteInPlace num.install --replace lib_root lib
-          ${pkgs.opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR num.install
+          ${nixpkgs.opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR num.install
         '';
     });
 

--- a/nix/overlay/default.nix
+++ b/nix/overlay/default.nix
@@ -101,6 +101,11 @@ let
         mkdir -p "$out/lib/ocaml/4.14.0/site-lib/stublibs"
         mv $out/lib/ocaml/4.14.0/site-lib/num/*.so "$out/lib/ocaml/4.14.0/site-lib/stublibs"
       '';
+      installPhase = ''
+          # Not sure if this is entirely correct, but opaline doesn't like `lib_root`
+          substituteInPlace num.install --replace lib_root lib
+          ${pkgs.opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR num.install
+        '';
     });
 
     odoc = super.odoc.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
Fixes and simplifies https://github.com/rizo/onix/pull/18:

1. Use `nixpkgs` instead of `pkgs`;
2. Remove `postInstall` since it's no longer needed for modern install.